### PR TITLE
fixup! pipeline.yaml: Add Chromebook for testing on x86-board kernels

### DIFF
--- a/config/pipeline.yaml
+++ b/config/pipeline.yaml
@@ -104,8 +104,11 @@ jobs:
   #   template: 'fstests.jinja2'
   #   image: 'kernelci/staging-kernelci'
 
-  baseline-x86:
+  baseline-x86: &baseline-x86-job
     template: baseline.jinja2
+
+  baseline-x86-board:
+    <<: *baseline-x86-job
 
   kbuild-gcc-10-x86:
     template: kbuild.jinja2


### PR DESCRIPTION
Initial patch for adding Chromebook to a pipeline added a schedule entry with non-existent job.

This change allows running that schedule by providing an actual job for it.

This type of job/schedule combo should probably be omitted in future. It does not introduce meaningful changes (it is mostly a rename) but currently saves a purpose of an example for adding new jobs/schedules.

Please squash this change to your patch in your PR kernelci/kernelci-pipeline#352